### PR TITLE
Add Amazon Associate integration

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -171,3 +171,24 @@ h2 {
 .bookmark-favicon {
   margin-right: 8px;
 }
+
+.amazon-associate {
+  margin-top: 1em;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 10px;
+  text-align: left;
+}
+
+.amazon-associate img {
+  width: 100px;
+  height: auto;
+}
+
+.amazon-associate-price {
+  color: #d66;
+  margin-top: 4px;
+}

--- a/src/components/AmazonAssociate.tsx
+++ b/src/components/AmazonAssociate.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+interface AmazonProduct {
+  asin?: string;
+  title?: string;
+  imageUrl?: string;
+  detailPageUrl?: string;
+  author?: string;
+  brand?: string;
+  price?: string;
+  priceValue?: number;
+}
+
+interface AmazonSearchResult {
+  keyword: string;
+  products: AmazonProduct[];
+  searchedAt: string;
+}
+
+interface AmazonAssociateProps {
+  date: string;
+}
+
+const AmazonAssociate = ({ date }: AmazonAssociateProps) => {
+  const [product, setProduct] = useState<AmazonProduct | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setProduct(null);
+      try {
+        const [y, m, d] = date.split("-");
+        const path = `./data/${y}/${m}/${d}.amazon.json`;
+        const res = await fetch(path);
+        if (!res.ok) return;
+        const data = (await res.json()) as AmazonSearchResult[];
+        const results = data.filter((r) => r.products && r.products.length > 0);
+        if (results.length === 0) return;
+
+        const weights = results.map((r) => r.products.length);
+        const total = weights.reduce((a, b) => a + b, 0);
+        let r = Math.random() * total;
+        let chosen: AmazonSearchResult = results[0];
+        for (let i = 0; i < results.length; i++) {
+          if (r < weights[i]) {
+            chosen = results[i];
+            break;
+          }
+          r -= weights[i];
+        }
+        const item =
+          chosen.products[Math.floor(Math.random() * chosen.products.length)];
+        setProduct(item);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    if (date) {
+      fetchData();
+    }
+  }, [date]);
+
+  if (!product) return null;
+
+  return (
+    <div className="amazon-associate">
+      {product.imageUrl && (
+        <a href={product.detailPageUrl} target="_blank" rel="noopener noreferrer">
+          <img src={product.imageUrl} alt={product.title ?? "Amazon product"} />
+        </a>
+      )}
+      <div className="amazon-associate-details">
+        <a href={product.detailPageUrl} target="_blank" rel="noopener noreferrer">
+          {product.title}
+        </a>
+        {product.author && <div className="amazon-associate-author">{product.author}</div>}
+        {!product.author && product.brand && (
+          <div className="amazon-associate-author">{product.brand}</div>
+        )}
+        {product.price && (
+          <div className="amazon-associate-price">{product.price}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AmazonAssociate;

--- a/src/view/BookmarksView.tsx
+++ b/src/view/BookmarksView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import "../App.css";
+import AmazonAssociate from "../components/AmazonAssociate";
 
 interface BookmarkInfo {
   title: string;
@@ -81,13 +82,20 @@ function BookmarksView({ initialDate }: BookmarksProps) {
           <ul className="bookmark-list">
             {bookmarks.map((b) => (
               <li key={b.link} style={{ textAlign: "left" }}>
-                <img className="bookmark-favicon" width={15} height={15} src={`https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&size=32&url=${b.link.match(/^(https?:\/\/[^\/]+\/)/)?.[1]}`} alt="favicon" />
+                <img
+                  className="bookmark-favicon"
+                  width={15}
+                  height={15}
+                  src={`https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&size=32&url=${(() => { try { return new URL(b.link).origin + '/'; } catch { return ''; } })()}`}
+                  alt="favicon"
+                />
                 <a href={b.link} target="_blank" rel="noopener noreferrer">
                   {b.title}
                 </a>
               </li>
             ))}
           </ul>
+          <AmazonAssociate date={dateStr} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- show Amazon Associate recommendations if product data exists
- select a random product from available search results prioritizing keywords with more hits
- append the product under the bookmark list
- style the Amazon associate card

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_684e920fc4f88325b8a4f79884a006b8